### PR TITLE
Campaign signup documentation: support campaign groups.

### DIFF
--- a/documentation/messages/campaign.signup.transactional.md
+++ b/documentation/messages/campaign.signup.transactional.md
@@ -84,9 +84,14 @@ Accessed by connecting to RabbitMQ server and sending message in the following f
   /* Optional. Override Mobilecommons opt-in path. */
   mc_opt_in_path_id: Number,
 
-  /* Required. An array of variables to inject into Mandrill template. */
-  /* Required keys: "MEMBER_COUNT", "FNAME", "CAMPAIGN_TITLE",  */
-  /* "CAMPAIGN_LINK", "CALL_TO_ACTION", "STEP_ONE", "STEP_TWO", "STEP_THREE". */
+  /* Required. An array of variables to inject into Mandrill template.
+    Required keys: "MEMBER_COUNT", "FNAME", "CAMPAIGN_TITLE", "CAMPAIGN_LINK".
+
+    For single campaigns required:
+    "CALL_TO_ACTION", "STEP_ONE", "STEP_TWO", "STEP_THREE".
+
+    For campaign groups required: "CAMPAIGN_COPY".
+  */
   merge_vars: Array,
 
 }
@@ -139,6 +144,7 @@ Changes:
 - :x: `merge_var: STEP_ONE` value from Phoenix
 - :x: `merge_var: STEP_TWO` value from Phoenix
 - :x: `merge_var: STEP_THREE` value from Phoenix
+- :x: `merge_var: CAMPAIGN_COPY` value from Phoenix
 - :x: `merge_var: FNAME` value from Northstar
 - :x: `mailchimp_list_id` value from Phoenix
 - :x: `mailchimp_grouping_id` value from Phoenix

--- a/documentation/messages/campaign.signup.transactional.md
+++ b/documentation/messages/campaign.signup.transactional.md
@@ -30,7 +30,7 @@ Accessed by connecting to RabbitMQ server and sending message in the following f
 ```js
 {
 
-  /* Required. Always must be "campaign_signup". */
+  /* Required. Must be "campaign_signup" or "campaign_group_signup". */
   activity: String,
 
   /* Required. */
@@ -48,7 +48,10 @@ Accessed by connecting to RabbitMQ server and sending message in the following f
   /* Required, Example: "en". */
   user_language: String,
 
-  /* Optional. Default is generated base on "user_country" field. Example: "mb-campaign-signup-US". */
+  /*
+    Optional. Default is generated base on "user_country" field.
+    Example: "mb-campaign-signup-US", "mb-campaign-group-signup-US"
+  */
   email_template: String,
 
   /* Required. Unix timestamp. Example: "1458067430". */
@@ -84,7 +87,8 @@ Accessed by connecting to RabbitMQ server and sending message in the following f
   /* Optional. Override Mobilecommons opt-in path. */
   mc_opt_in_path_id: Number,
 
-  /* Required. An array of variables to inject into Mandrill template.
+  /*
+    Required. An array of variables to inject into Mandrill template.
     Required keys: "MEMBER_COUNT", "FNAME", "CAMPAIGN_TITLE", "CAMPAIGN_LINK".
 
     For single campaigns required:


### PR DESCRIPTION
The only difference between single campaign and campaign groups is in merge tags:
https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module#L181
