### PR TITLE
Changes campaign_country to campaign_language

### DIFF
--- a/documentation/messages/campaign.signup.transactional.md
+++ b/documentation/messages/campaign.signup.transactional.md
@@ -117,8 +117,8 @@ Accessed by connecting to RabbitMQ server and sending message in the following f
   /* Required. Phoenix campaign id. Example: "1334". */
   campaign_id: Number,
 
-  /* Required. A country of campaign user subscribed to. Example: "US". */
-  campaign_country: String,
+  /* Required. The language of the campaign the user subscribed to. Example: "en". */
+  campaign_language: String,
 
   /* Optional. The default is generated base on "user_country" value gathered */
   /* from user settings found for "email" or "user_id". */


### PR DESCRIPTION
Fixes #19 

Change parameter `campaign_country` to `campaign_language for`POST /campaign/signup`.

Supports having campaigns in various languages independent of the country the campaign is from.
