### PR TITLE
Issue28 test coverage enquiry endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "debug": "node debug app.js",
     "start": "node app.js",
-    "test": "node ./node_modules/mocha/bin/mocha test/bootstrap.test.js"
+    "test": "node ./node_modules/mocha/bin/mocha test/bootstrap.test.js test/**/*.test.js"
   },
   "main": "app.js",
   "repository": {

--- a/test/integration/controllers/RootController.test.js
+++ b/test/integration/controllers/RootController.test.js
@@ -22,3 +22,23 @@ describe('Requests to the root (/api) path', function() {
   });
 
 });
+
+/**
+ * Test API V1 information / status endpoint.
+ */
+describe('Requests to v1 root (/api/v1) path', function() {
+
+  it('GET: Returns a 200 status code', function(done) {
+
+    request(sails.hooks.http.app)
+      .get('/api/v1')
+      .expect(200, done);
+  });
+
+  it('GET: Returns JSON format', function(done) {
+
+    request(sails.hooks.http.app)
+      .get('/api/v1')
+      .expect("content-type", /json/, done)
+  });
+});

--- a/test/integration/controllers/RootController.test.js
+++ b/test/integration/controllers/RootController.test.js
@@ -1,0 +1,24 @@
+/**
+ * RootController.test.js
+ */
+var request = require('supertest');
+var should = require('should');
+
+/**
+ * Test API "ping" endpoint.
+ */
+describe('Requests to the root (/api) path', function() {
+  
+  it('GET: Returns a 200 status code', function (done) {
+    request(sails.hooks.http.app)
+      .get('/api')
+      .expect(200, done);
+  });
+    
+  it('GET: Returns JSON format', function(done) {
+    request(app)
+      .get('/api')
+      .expect("content-type", /json/, done)
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --recursive
----require should
+--require should

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
---timeout 5s
 --recursive
 --require should

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
+--timeout 5s
 --recursive
 --require should

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
---timeout 5s
 --recursive
---require should
+---require should


### PR DESCRIPTION
Fixes #28 

Basic test coverage for #4

```
$ npm test

> quicksilver-api@0.0.0 test /Users/darrenlee/Sites/message-broker/quicksilver-api
> node ./node_modules/mocha/bin/mocha test/bootstrap.test.js test/**/*.test.js

info:
info:                .-..-.
info:
info:    Sails              <|    .-..-.
info:    v0.12.3             |\
info:                       /|.\
info:                      / || \
info:                    ,'  |'  \
info:                 .-'.-==|/_--'
info:                 `--'-------'
info:    __---___--___---___--___---___--___
info:  ____---___--___---___--___---___--___-__
info:
info: Server lifted in `/Users/darrenlee/Sites/message-broker/quicksilver-api`
info: To see your app, visit http://localhost:1337
info: To shut down Sails, press <CTRL> + C at any time.

debug: -------------------------------------------------------
debug: :: Wed Apr 06 2016 20:58:01 GMT-0400 (EDT)

debug: Environment : development
debug: Port        : 1337
debug: -------------------------------------------------------
  Requests to the root (/api) path
    1) GET: Returns a 200 status code
    2) GET: Returns JSON format

  Requests to v1 root (/api/v1) path
    3) GET: Returns a 200 status code
    4) GET: Returns JSON format


  0 passing (2s)
  4 failing
```
