### PR TITLE
Issue31 document systems using

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API gateway to Quicksilver (Message Broker) functionality.
 | `POST /campaign/reportback` | [Campaign report back](documentation/endpoints/campaign.md#campaign-report-back) | [campaign.report_back.transactional](documentation/messages/campaign.signup.transactional.md) |
 
 ## Tests
-Test coverage uses the following untilities:
+Test coverage uses the following utilities:
 - [Mocha](https://www.npmjs.com/package/mocha)
 - [Should](https://www.npmjs.com/package/should)
 - [Supertest](https://www.npmjs.com/package/supertest)

--- a/documentation/references/systems.md
+++ b/documentation/references/systems.md
@@ -1,0 +1,9 @@
+# `quicksilver` Systems
+
+##### Purpose
+A listing of internal `quicksilver` systems.
+
+| System | Producers / Consumers | Description |
+| ------ | --------------------- | ----------- |
+| [User Import](https://github.com/DoSomething/mbp-user-import/wiki) | mbp-user-import_manageData | Gather CSV files from `machines@dosomething.org gmail account. |
+|        | mbp-user-import | Process CSV file contents to create message entries in `userImportQueue`. |                                       

--- a/documentation/references/systemsUsing.md
+++ b/documentation/references/systemsUsing.md
@@ -1,0 +1,8 @@
+# Systems Using `quicksilver-api`
+
+##### Purpose
+A listing of systems that access `quicksilver-api` endpoints.
+
+| System | Endpoints Used | Notes |
+| ------ | -------------- | ----- |
+| ...    |                |       |


### PR DESCRIPTION
Fixes #31 

Need documentation home to:
-  list **Systems that use the `quicksilver-api` as well as point to other system documentation in general.
- list internal `quicksilver` systems that access the infrastructure the `quicksilver-api` is providing a gateway to.
- Required by Trello Card "Link Co-Reg Documentation"
  - https://trello.com/c/i6zkVWmF
