### PR TITLE
Issue43 add expect

### DIFF
--- a/test/integration/controllers/UserPasswordResetController.test.js
+++ b/test/integration/controllers/UserPasswordResetController.test.js
@@ -47,7 +47,7 @@ describe('Requests to the root (/user/password) path', function() {
         }
         response.status.should.equal(200);
         response.body[0].should.have.property('activity');
-        response.body[0].activity.should.equal("user_password");
+        response.body[0].activity.should.equal('user_password');
         response.body[0].should.have.property('email');
         response.body[0].should.have.property('uid');
         response.body[0].should.have.property('merge_vars');
@@ -80,7 +80,7 @@ describe('Requests to the root (/user/password) path', function() {
         }
         response.status.should.equal(200)
         response.body[0].should.have.property('activity');
-        response.body[0].activity.should.equal("user_password");
+        response.body[0].activity.should.equal('user_password');
         response.body[0].should.have.property('email');
         response.body[0].should.have.property('uid');
         response.body[0].should.have.property('merge_vars');
@@ -113,7 +113,7 @@ describe('Requests to the root (/user/password) path', function() {
         }
         response.status.should.equal(200)
         response.body[0].should.have.property('activity');
-        response.body[0].activity.should.equal("user_password");
+        response.body[0].activity.should.equal('user_password');
         response.body[0].should.have.property('email');
         response.body[0].should.have.property('uid');
         response.body[0].should.have.property('merge_vars');

--- a/test/integration/controllers/UserPasswordResetController.test.js
+++ b/test/integration/controllers/UserPasswordResetController.test.js
@@ -79,7 +79,21 @@ describe('Requests to the root (/user/password) path', function() {
           throw err;
         }
         response.status.should.equal(200)
-        response.body.should.equal("OK")
+        response.body[0].should.have.property('activity');
+        response.body[0].activity.should.equal("user_password");
+        response.body[0].should.have.property('email');
+        response.body[0].should.have.property('uid');
+        response.body[0].should.have.property('merge_vars');
+        response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
+        response.body[0].merge_vars.should.have.property('FNAME');
+        response.body[0].merge_vars.should.have.property('RESET_LINK');
+        response.body[0].should.have.property('user_country');
+        response.body[0].should.have.property('user_language');
+        response.body[0].should.have.property('email_template');
+        response.body[0].should.have.property('email_tags');
+        response.body[0].email_tags[0].should.equal('drupal_user_password');
+        response.body[0].should.have.property('activity_timestamp');
+        response.body[0].should.have.property('application_id');
         done();
       });
   });

--- a/test/integration/controllers/UserPasswordResetController.test.js
+++ b/test/integration/controllers/UserPasswordResetController.test.js
@@ -112,7 +112,21 @@ describe('Requests to the root (/user/password) path', function() {
           throw err;
         }
         response.status.should.equal(200)
-        response.body.should.equal("OK")
+        response.body[0].should.have.property('activity');
+        response.body[0].activity.should.equal("user_password");
+        response.body[0].should.have.property('email');
+        response.body[0].should.have.property('uid');
+        response.body[0].should.have.property('merge_vars');
+        response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
+        response.body[0].merge_vars.should.have.property('FNAME');
+        response.body[0].merge_vars.should.have.property('RESET_LINK');
+        response.body[0].should.have.property('user_country');
+        response.body[0].should.have.property('user_language');
+        response.body[0].should.have.property('email_template');
+        response.body[0].should.have.property('email_tags');
+        response.body[0].email_tags[0].should.equal('drupal_user_password');
+        response.body[0].should.have.property('activity_timestamp');
+        response.body[0].should.have.property('application_id');
         done();
       });
   });

--- a/test/integration/controllers/UserPasswordResetController.test.js
+++ b/test/integration/controllers/UserPasswordResetController.test.js
@@ -45,8 +45,22 @@ describe('Requests to the root (/user/password) path', function() {
         if (err) {
           throw err;
         }
-        response.status.should.equal(200)
-        response.body.should.equal("OK")
+        response.status.should.equal(200);
+        response.body[0].should.have.property('activity');
+        response.body[0].activity.should.equal("user_password");
+        response.body[0].should.have.property('email');
+        response.body[0].should.have.property('uid');
+        response.body[0].should.have.property('merge_vars');
+        response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
+        response.body[0].merge_vars.should.have.property('FNAME');
+        response.body[0].merge_vars.should.have.property('RESET_LINK');
+        response.body[0].should.have.property('user_country');
+        response.body[0].should.have.property('user_language');
+        response.body[0].should.have.property('email_template');
+        response.body[0].should.have.property('email_tags');
+        response.body[0].email_tags[0].should.equal('drupal_user_password');
+        response.body[0].should.have.property('activity_timestamp');
+        response.body[0].should.have.property('application_id');
         done();
       });
   });


### PR DESCRIPTION
Fixes #43 

Adds `should` test conditions to `/api/v1/users/password` responses to ensure the expected values are in the generated message when only the `user_id`, `email` or `mobile` are provided.

**To Test**:
- `$ npm test`
