### PR TITLE
Issue52 test errors

### DIFF
--- a/test/integration/controllers/v1/ApiController.test.js
+++ b/test/integration/controllers/v1/ApiController.test.js
@@ -16,7 +16,7 @@ describe('Requests to the root (/api) path', function() {
   });
 
   it('GET: Returns JSON format', function(done) {
-    request(app)
+    request(sails.hooks.http.app)
       .get('/api')
       .expect("content-type", /json/, done)
   });

--- a/test/integration/controllers/v1/UserController.test.js
+++ b/test/integration/controllers/v1/UserController.test.js
@@ -62,6 +62,7 @@ describe('Requests to the root (/user/password) path', function() {
       response.body[0].email_tags[0].should.equal('drupal_user_password');
       response.body[0].should.have.property('activity_timestamp');
       response.body[0].should.have.property('application_id');
+
       done();
     });
   });
@@ -106,7 +107,7 @@ describe('Requests to the root (/user/password) path', function() {
     .send({
       "mobile": "15556669999"
     })
-    .expect(201)
+    .expect(200)
     .expect("content-type", /json/)
     .end(function(err, response) {
       if (err) {

--- a/test/integration/controllers/v1/UserController.test.js
+++ b/test/integration/controllers/v1/UserController.test.js
@@ -62,7 +62,6 @@ describe('Requests to the root (/user/password) path', function() {
       response.body[0].email_tags[0].should.equal('drupal_user_password');
       response.body[0].should.have.property('activity_timestamp');
       response.body[0].should.have.property('application_id');
-
       done();
     });
   });


### PR DESCRIPTION
Fixes #52 
- [x] ReferenceError: app is not defined
  > Not sure what sails.hooks.http.app is though.
  https://github.com/DoSomething/quicksilver-api/blob/master/test/bootstrap.test.js#L1

```
var sails = require('sails');
```
- [x] Cannot read property 'should' of undefined. 
  > Should it check that body[0] exists first?
  No, if it's missing then the test should fail. The idea is a `POST` returns values it's response to confirm the `POST` worked as expected. Is that correct? Can the tests expect these values: 
  https://github.com/DoSomething/quicksilver-api/blob/408acb90b83bbc5c182290bbdc01454720335f23/test/integration/controllers/UserPasswordResetController.test.js#L82-L96

**To Test**:

```
$ npm test

  Requests to the root (/api) path
    ✓ GET: Returns a 200 status code (163ms)
    ✓ GET: Returns JSON format

  Requests to v1 root (/api/v1) path
    ✓ GET: Returns a 200 status code
    ✓ GET: Returns JSON format

  Requests to the root (/user/password) path with missing required body parameters.
    1) POST: Invalid password reset request with missing body parameters returns expected 422 - Unprocessable due to request validation error results.

  Requests to the root (/user/password) path
    2) POST: Valid password request with only user_id returns expected results.
    3) POST: Valid password request with only email returns expected results.
    4) POST: Valid password request with only mobile returns expected results.


  4 passing (2s)
  4 failing
```
