### PR TITLE
Issue54 test api and v1 responses

### DIFF
--- a/test/integration/controllers/v1/ApiController.test.js
+++ b/test/integration/controllers/v1/ApiController.test.js
@@ -21,7 +21,7 @@ describe('Requests to the root (/api) path', function() {
       .expect("content-type", /json/, done)
   });
 
-  it('GET: Returns v1 route', function(done) {
+  it('GET: Redirects to v1 path and returns v1 route details', function(done) {
     request(sails.hooks.http.app)
       .get('/api')
       .expect("content-type", /json/)
@@ -53,7 +53,7 @@ describe('Requests to v1 root (/api/v1) path', function() {
       .expect("content-type", /json/, done)
   });
 
-  it('GET: Returns v1 route', function(done) {
+  it('GET: Returns v1 paths', function(done) {
 
     request(sails.hooks.http.app)
       .get('/api/v1')

--- a/test/integration/controllers/v1/ApiController.test.js
+++ b/test/integration/controllers/v1/ApiController.test.js
@@ -32,7 +32,6 @@ describe('Requests to the root (/api) path', function() {
         done();
       });
   });
-
 });
 
 /**
@@ -52,5 +51,21 @@ describe('Requests to v1 root (/api/v1) path', function() {
     request(sails.hooks.http.app)
       .get('/api/v1')
       .expect("content-type", /json/, done)
+  });
+
+  it('GET: Returns v1 route', function(done) {
+
+    request(sails.hooks.http.app)
+      .get('/api/v1')
+      .expect("content-type", /json/)
+      .end(function(err, res) {
+        if (err) throw err;
+        res.body.should.have.property('user');
+        res.body.user.should.have.property('register');
+        res.body.user.register.should.endWith('/api/v1/user/register');
+        res.body.user.should.have.property('password');
+        res.body.user.password.should.endWith('/api/v1/user/password');
+        done();
+      });
   });
 });

--- a/test/integration/controllers/v1/ApiController.test.js
+++ b/test/integration/controllers/v1/ApiController.test.js
@@ -16,9 +16,21 @@ describe('Requests to the root (/api) path', function() {
   });
 
   it('GET: Returns JSON format', function(done) {
-    request(app)
+    request(sails.hooks.http.app)
       .get('/api')
       .expect("content-type", /json/, done)
+  });
+
+  it('GET: Returns v1 route', function(done) {
+    request(sails.hooks.http.app)
+      .get('/api')
+      .expect("content-type", /json/)
+      .end(function(err, res) {
+        if (err) throw err;
+        res.body.should.have.property('v1');
+        res.body.v1.should.endWith('/api/v1');
+        done();
+      });
   });
 
 });

--- a/test/integration/controllers/v1/UserController.test.js
+++ b/test/integration/controllers/v1/UserController.test.js
@@ -47,21 +47,21 @@ describe('Requests to the root (/user/password) path', function() {
         throw err;
       }
       response.status.should.equal(200);
-      response.body[0].should.have.property('activity');
-      response.body[0].activity.should.equal('user_password');
-      response.body[0].should.have.property('email');
-      response.body[0].should.have.property('uid');
-      response.body[0].should.have.property('merge_vars');
-      response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
-      response.body[0].merge_vars.should.have.property('FNAME');
-      response.body[0].merge_vars.should.have.property('RESET_LINK');
-      response.body[0].should.have.property('user_country');
-      response.body[0].should.have.property('user_language');
-      response.body[0].should.have.property('email_template');
-      response.body[0].should.have.property('email_tags');
-      response.body[0].email_tags[0].should.equal('drupal_user_password');
-      response.body[0].should.have.property('activity_timestamp');
-      response.body[0].should.have.property('application_id');
+      response.body.should.have.property('activity');
+      response.body.activity.should.equal('user_password');
+      response.body.should.have.property('email');
+      response.body.should.have.property('uid');
+      response.body.should.have.property('merge_vars');
+      response.body.merge_vars.should.have.property('MEMBER_COUNT');
+      response.body.merge_vars.should.have.property('FNAME');
+      response.body.merge_vars.should.have.property('RESET_LINK');
+      response.body.should.have.property('user_country');
+      response.body.should.have.property('user_language');
+      response.body.should.have.property('email_template');
+      response.body.should.have.property('email_tags');
+      response.body.email_tags[0].should.equal('drupal_user_password');
+      response.body.should.have.property('activity_timestamp');
+      response.body.should.have.property('application_id');
       done();
     });
   });
@@ -80,21 +80,21 @@ describe('Requests to the root (/user/password) path', function() {
         throw err;
       }
       response.status.should.equal(200)
-      response.body[0].should.have.property('activity');
-      response.body[0].activity.should.equal('user_password');
-      response.body[0].should.have.property('email');
-      response.body[0].should.have.property('uid');
-      response.body[0].should.have.property('merge_vars');
-      response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
-      response.body[0].merge_vars.should.have.property('FNAME');
-      response.body[0].merge_vars.should.have.property('RESET_LINK');
-      response.body[0].should.have.property('user_country');
-      response.body[0].should.have.property('user_language');
-      response.body[0].should.have.property('email_template');
-      response.body[0].should.have.property('email_tags');
-      response.body[0].email_tags[0].should.equal('drupal_user_password');
-      response.body[0].should.have.property('activity_timestamp');
-      response.body[0].should.have.property('application_id');
+      response.body.should.have.property('activity');
+      response.body.activity.should.equal('user_password');
+      response.body.should.have.property('email');
+      response.body.should.have.property('uid');
+      response.body.should.have.property('merge_vars');
+      response.body.merge_vars.should.have.property('MEMBER_COUNT');
+      response.body.merge_vars.should.have.property('FNAME');
+      response.body.merge_vars.should.have.property('RESET_LINK');
+      response.body.should.have.property('user_country');
+      response.body.should.have.property('user_language');
+      response.body.should.have.property('email_template');
+      response.body.should.have.property('email_tags');
+      response.body.email_tags[0].should.equal('drupal_user_password');
+      response.body.should.have.property('activity_timestamp');
+      response.body.should.have.property('application_id');
       done();
     });
   });
@@ -106,28 +106,28 @@ describe('Requests to the root (/user/password) path', function() {
     .send({
       "mobile": "15556669999"
     })
-    .expect(201)
+    .expect(200)
     .expect("content-type", /json/)
     .end(function(err, response) {
       if (err) {
         throw err;
       }
       response.status.should.equal(200)
-      response.body[0].should.have.property('activity');
-      response.body[0].activity.should.equal('user_password');
-      response.body[0].should.have.property('email');
-      response.body[0].should.have.property('uid');
-      response.body[0].should.have.property('merge_vars');
-      response.body[0].merge_vars.should.have.property('MEMBER_COUNT');
-      response.body[0].merge_vars.should.have.property('FNAME');
-      response.body[0].merge_vars.should.have.property('RESET_LINK');
-      response.body[0].should.have.property('user_country');
-      response.body[0].should.have.property('user_language');
-      response.body[0].should.have.property('email_template');
-      response.body[0].should.have.property('email_tags');
-      response.body[0].email_tags[0].should.equal('drupal_user_password');
-      response.body[0].should.have.property('activity_timestamp');
-      response.body[0].should.have.property('application_id');
+      response.body.should.have.property('activity');
+      response.body.activity.should.equal('user_password');
+      response.body.should.have.property('email');
+      response.body.should.have.property('uid');
+      response.body.should.have.property('merge_vars');
+      response.body.merge_vars.should.have.property('MEMBER_COUNT');
+      response.body.merge_vars.should.have.property('FNAME');
+      response.body.merge_vars.should.have.property('RESET_LINK');
+      response.body.should.have.property('user_country');
+      response.body.should.have.property('user_language');
+      response.body.should.have.property('email_template');
+      response.body.should.have.property('email_tags');
+      response.body.email_tags[0].should.equal('drupal_user_password');
+      response.body.should.have.property('activity_timestamp');
+      response.body.should.have.property('application_id');
       done();
     });
   });


### PR DESCRIPTION
Fixes #54 
- Addition of tests to ensure `/api` and `/api/v1` are responding with expected values
- Adjusted  `/api/v1/user/password` test expect values to not point at `body[0]` but rather `body`.

**To Test**:

```
$ npm test

  Requests to the root (/api) path
    ✓ GET: Returns a 200 status code (84ms)
    ✓ GET: Returns JSON format
    ✓ GET: Returns v1 route

  Requests to v1 root (/api/v1) path
    ✓ GET: Returns a 200 status code
    ✓ GET: Returns JSON format
    ✓ GET: Returns v1 route

  Requests to the root (/user/password) path with missing required body parameters.
    1) POST: Invalid password reset request with missing body parameters returns expected 422 - Unprocessable due to request validation error results.

  Requests to the root (/user/password) path
    2) POST: Valid password request with only user_id returns expected results.
    3) POST: Valid password request with only email returns expected results.
    4) POST: Valid password request with only mobile returns expected results.


  6 passing (5s)
  4 failing
```
