### PR TITLE
Fix mocha tests run: include coffee.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "debug": "sails debug",
     "start": "node app.js",
-    "test": "NODE_ENV=test node ./node_modules/mocha/bin/mocha --compilers coffee:coffee-script test/bootstrap.test.js test/**/*.test.js"
+    "test": "NODE_ENV=test node ./node_modules/mocha/bin/mocha --require coffee-script/register --compilers coffee:coffee-script test/bootstrap.test.js test/**/*.test.js test/**/*.test.coffee"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
After migrating tests to CoffeeScript in #66, we forgot to include `*.test.coffee` files to the list of mocha files to parse. This PR is to fix this issue.
#### Before

```
  0 passing (2ms)
```
#### After

```
  6 passing (3s)
  3 failing
```
