### PR TITLE
Functional validation for one of three parameter

### DIFF
--- a/api/models/UserPassword.js
+++ b/api/models/UserPassword.js
@@ -26,25 +26,19 @@ module.exports = {
   attributes: {
     user_id: {
       type: 'string',
-      required: function() {
-        return !this.email && !this.mobile;
-      },
+      required: () => !this.email && !this.mobile,
       hexadecimal: true,
       defaultsTo: '',
     },
     email: {
       type: 'string',
-      required: function() {
-        return !this.user_id && !this.mobile;
-      },
+      required: () => !this.user_id && !this.mobile,
       email: true,
       defaultsTo: '',
     },
     mobile: {
       type: 'string',
-      required: function() {
-        return !this.user_id && !this.email;
-      },
+      required: () => !this.user_id && !this.email,
       defaultsTo: '',
     },
     application_id: {

--- a/api/models/UserPassword.js
+++ b/api/models/UserPassword.js
@@ -2,6 +2,17 @@
 
 const Promise = require('bluebird');
 
+/*
+ * Validate that at least one of the user fields have a value
+ *
+ * @param string userField
+ *   The name of the field
+ */
+function isOneOfFieldSet() {
+  // TODO: Move to module
+  return ['user_id', 'email', 'mobile'].every(userField => !this[userField]);
+}
+
 /**
  * UserPassword
  *
@@ -26,19 +37,19 @@ module.exports = {
   attributes: {
     user_id: {
       type: 'string',
-      required: () => !this.email && !this.mobile,
+      required: isOneOfFieldSet,
       hexadecimal: true,
       defaultsTo: '',
     },
     email: {
       type: 'string',
-      required: () => !this.user_id && !this.mobile,
+      required: isOneOfFieldSet,
       email: true,
       defaultsTo: '',
     },
     mobile: {
       type: 'string',
-      required: () => !this.user_id && !this.email,
+      required: isOneOfFieldSet,
       defaultsTo: '',
     },
     application_id: {
@@ -73,10 +84,5 @@ module.exports = {
       );
     },
   },
-
-  /**
-   * Validate the presences of at least one of the fields.
-   */
-
 
 };

--- a/api/models/UserPassword.js
+++ b/api/models/UserPassword.js
@@ -10,6 +10,7 @@ const Promise = require('bluebird');
  */
 
 module.exports = {
+
   // Allow only whitelisted attributes.
   schema: true,
 
@@ -25,19 +26,25 @@ module.exports = {
   attributes: {
     user_id: {
       type: 'string',
-      required: true,
+      required: function() {
+        return !this.email && !this.mobile;
+      },
       hexadecimal: true,
       defaultsTo: '',
     },
     email: {
       type: 'string',
-      required: true,
+      required: function() {
+        return !this.user_id && !this.mobile;
+      },
       email: true,
       defaultsTo: '',
     },
     mobile: {
       type: 'string',
-      required: true,
+      required: function() {
+        return !this.user_id && !this.email;
+      },
       defaultsTo: '',
     },
     application_id: {
@@ -76,32 +83,6 @@ module.exports = {
   /**
    * Validate the presences of at least one of the fields.
    */
-  beforeValidate(values, cb) {
-    // TODO: Replace this with custom attribute validation method:
-    // https://github.com/balderdashy/waterline-docs/blob/master/models/validations.md#custom-validations
 
-    // The list of possible fields.
-    const fields = ['user_id', 'email', 'mobile'];
-
-    // Check if at least one field is present and truthy.
-    const found = fields.some(field => values[field]);
-
-    // Turn off presence validations when at least one fields is present,
-    // turn on when all fields are absent.
-    fields.forEach((field) => {
-      if (found) {
-        // It should be possible to just set required to false,
-        // but for some reason it turns off the rest of field rules.
-        delete this._validator.validations[field].required;
-      } else {
-        // Reenable presence validation if no fields found.
-        this._validator.validations[field].required = true;
-      }
-      return true;
-    });
-
-    // Continue.
-    cb();
-  },
 
 };


### PR DESCRIPTION
Fixes #81 

Adds validation to `POST /api/v1/user/password` for at least one of `user_id`, `email`, or `mobile`.

**To Test**:
- `POST` to `/api/v1/user/password` with a body of:

```
{
  "email": "test@test.com",
  "application_id": "US",
  "email_template": "mb-user-password-reset"
}
```

✅ returns:

```
{
  "activity": "user_password",
  "email": "test@test.com",
  "uid": "1700142",
  "merge_vars": {
    "MEMBER_COUNT": "3.5 million",
    "FNAME": "Test",
    "RESET_LINK": null
  },
  "user_country": null,
  "user_language": null,
  "email_template": null,
  "email_tags": [
    "user_password"
  ],
  "activity_timestamp": null,
  "application_id": null
}
```
- `POST` to `/api/v1/user/password` with a body of:

```
{
  "application_id": "US",
  "email_template": "mb-user-password-reset"
}
```

✅ returns:

```
{
  "reason": "3 attributes are invalid",
  "errors": {
    "user_id": [
      {
        "rule": "required",
        "message": "\"required\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"
      },
      {
        "rule": "hexadecimal",
        "message": "\"hexadecimal\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"
      }
    ],
    "email": [
      {
        "rule": "required",
        "message": "\"required\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"
      },
      {
        "rule": "email",
        "message": "\"email\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"
      }
    ],
    "mobile": [
      {
        "rule": "required",
        "message": "\"required\" validation rule failed for input: ''\nSpecifically, it threw an error.  Details:\n undefined"
      }
    ]
  }
}
```
