### PR TITLE
Fixes js linting in nested folders.

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -4,3 +4,6 @@
     # See http://sailsjs.org/documentation/concepts/services
     NorthstarService: false
     PhoenixService: false
+    # Models are exposed as global variables using their globalId.
+    # See http://sailsjs.org/documentation/concepts/globals#/models-and-services
+    UserPassword: false

--- a/api/controllers/v1/ApiController.js
+++ b/api/controllers/v1/ApiController.js
@@ -16,9 +16,9 @@ module.exports = {
     return res.json({
       user: {
         register: sails.config.appUrl + sails.getUrlFor('v1/UserController.register'),
-        password: sails.config.appUrl + sails.getUrlFor('v1/UserController.password')
-      }
+        password: sails.config.appUrl + sails.getUrlFor('v1/UserController.password'),
+      },
     });
-  }
+  },
 
 };

--- a/api/controllers/v1/UserController.js
+++ b/api/controllers/v1/UserController.js
@@ -15,7 +15,7 @@ module.exports = {
   index(req, res) {
     return res.json({
       register: sails.config.appUrl + sails.getUrlFor('v1/UserController.register'),
-      password: sails.config.appUrl + sails.getUrlFor('v1/UserController.password')
+      password: sails.config.appUrl + sails.getUrlFor('v1/UserController.password'),
     });
   },
 
@@ -25,7 +25,7 @@ module.exports = {
    */
   register(req, res) {
     return res.json({
-      todo: 'register() is not implemented yet!'
+      todo: 'register() is not implemented yet!',
     });
   },
 
@@ -38,5 +38,5 @@ module.exports = {
     .then(result => result.toMessage())
     .then(message => res.send(message))
     .caught(error => res.negotiate(error));
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "sails debug",
     "start": "node app.js",
     "test": "npm run lint && NODE_ENV=test mocha test/bootstrap.test.js test/**/*.test.js",
-    "lint": "eslint test/**/*.js api/**/*.js"
+    "lint": "eslint --ext=.js test/ api/"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
For some reason `eslint test/**/*.js api/**/*.js` includes only files nested on the first level, so controllers in `v1/` folder got ignored.

This PR adresses this issue and fixes the codestyle in such files.
