### PR TITLE
Minor: custom timeout for Mocha integration tests.

### DIFF
--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -5,8 +5,6 @@
 const sails = require('sails');
 
 before(function (done) {
-  // Increase the Mocha timeout so that Sails has enough time to lift.
-  this.timeout(50000);
   sails.lift({}, (err) => {
     if (err) {
       return done(err);

--- a/test/integration/controllers/v1/UserController.test.js
+++ b/test/integration/controllers/v1/UserController.test.js
@@ -98,17 +98,20 @@ describe('POST /user/password', () => {
   });
 
   /* Only user_id field posted. */
-  it('should accept test `user_id` and return expected json payload', (done) => {
+  it('should prepare the payload for `user_id`', function (done) {
+    this.timeout(5000);
     postValidDataAndCheckResponse(done, { user_id: '5480c950bffebc651c8b456f' });
   });
 
   /* Only email field posted. */
-  it('should accept test `email` and return expected json payload', (done) => {
+  it('should prepare the payload for `email`', function (done) {
+    this.timeout(5000);
     postValidDataAndCheckResponse(done, { email: 'test@dosomething.org' });
   });
 
   /* Only mobile field posted. */
-  it('should accept test `mobile` and return expected json payload', (done) => {
+  it('should prepare the payload for `mobile`', function (done) {
+    this.timeout(5000);
     postValidDataAndCheckResponse(done, { mobile: '5555555555' });
   });
 });


### PR DESCRIPTION
This PR increases mocha timeout for time-consuming tests that rely on external servers.
I thought #91 would fix it, but turned out it was not a global timeout, but local, relevant only for `before()` hook.
