### PR TITLE
Running dependent services with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ API gateway to Quicksilver (Message Broker) functionality.
 | `POST /campaign/signup`     | [Campaign signup](documentation/endpoints/campaign.md#campaign-signup)           | [campaign.signup.transactional](documentation/messages/campaign.signup.transactional.md)      |
 | `POST /campaign/reportback` | [Campaign report back](documentation/endpoints/campaign.md#campaign-report-back) | [campaign.report_back.transactional](documentation/messages/campaign.signup.transactional.md) |
 
-## Development.
-#### Requirements
+## Development
+### Requirements
 - [Node.js](https://nodejs.org/en/download/) v4.4
 - [Docker](https://www.docker.com/products/overview) with support
   of Compose file [v2](https://docs.docker.com/compose/compose-file/#/versioning)
-  for running dependent services, for example RabbitMQ.
+  for running dependent services (like RabbitMQ).
 
-#### Installation
+### Installation
 1. Install dependencies `npm install`
-2. Create config/local.js file with following settings:
-   
-```js
+2. Create `config/local.js` file with following settings:
+
+   ```js
    module.exports = {
       // Northstar.
       northstar: {
@@ -44,7 +44,7 @@ API gateway to Quicksilver (Message Broker) functionality.
        password: '{{ phoenix_api_pass }}',
       },
 
-     // RabbitMQ
+     // RabbitMQ.
      amqp: {
        management: {
          username: 'dosomething',
@@ -62,26 +62,25 @@ API gateway to Quicksilver (Message Broker) functionality.
          vhost: 'dosomething',
        },
      },
-
    };
 ```
 
-#### Dependent services
-**Start**:
+### Dependent services
+#### Start
 
-1. Make sure Docker is running.
+1. Make sure Docker is running
 2. Run `npm run start-dev-services`
 
-**Stop**:
+#### Stop
 
 Run `npm run stop-dev-services`.
 
-**Available services**:
+#### Available services
 
-- [`localhost:5672`](http://localhost:5672): RabbitMQ AMQP
+- `localhost:5672`: RabbitMQ AMQP
 - [`localhost:15672`](http://localhost:15672): RabbitMQ management
 
-#### Running app in development mode
+### Running app in development mode
 
 **Important**: Make sure dependent services are up and running.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quicksilver-API
+# Quicksilver-API [![wercker status](https://app.wercker.com/status/ee29a549f6d3b68e7b3cb101a7c9a943/s/master "wercker status")](https://app.wercker.com/project/bykey/ee29a549f6d3b68e7b3cb101a7c9a943)
 API gateway to Quicksilver (Message Broker) functionality.
 
 ## Endpoints
@@ -66,28 +66,44 @@ API gateway to Quicksilver (Message Broker) functionality.
    };
 ```
 
-#### Running Sails
+#### Dependent services
+**Start**:
 
-Run Sails as usual by executing `sails lift` or `npm start`.
+1. Make sure Docker is running.
+2. Run `npm run start-dev-services`
 
-To automatically restart Sails on any changes to .js and .json files, run
-`nodemon` instead.
+**Stop**:
 
+Run `npm run stop-dev-services`.
 
+**Available services**:
+
+- [`localhost:5672`](http://localhost:5672): RabbitMQ AMQP
+- [`localhost:15672`](http://localhost:15672): RabbitMQ management
+
+#### Running app in development mode
+
+**Important**: Make sure dependent services are up and running.
+
+Watch mode (prefered):
+Run `nodemon` to lift up the application and watch for code changes. Application
+will be reloaded on any changes in `.js` and `.json` files.
+
+Normal mode:
+You can start Sails as usual by running `sails lift` or `npm start`.
 
 ## Tests
 
-Master build status:
-
-[![wercker status](https://app.wercker.com/status/ee29a549f6d3b68e7b3cb101a7c9a943/s/master "wercker status")](https://app.wercker.com/project/bykey/ee29a549f6d3b68e7b3cb101a7c9a943)
-
-Test coverage uses the following utilities:
-- [Mocha](https://www.npmjs.com/package/mocha)
-- [Should](https://www.npmjs.com/package/should)
-- [Supertest](https://www.npmjs.com/package/supertest)
+**Important**: Make sure dependent services are up and running.
 
 To run all of the tests defined in `/test` recursively.
 
 ```
 $ npm test
 ```
+
+Test and code style coverage uses the following utilities:
+- [Mocha](https://www.npmjs.com/package/mocha)
+- [Should](https://www.npmjs.com/package/should)
+- [Supertest](https://www.npmjs.com/package/supertest)
+- [ESLint](http://eslint.org/)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Run `npm run stop-dev-services`.
 #### Available services
 
 - `localhost:5672`: RabbitMQ AMQP
-- [`localhost:15672`](http://localhost:15672): RabbitMQ management
+- [`localhost:15672`](http://localhost:15672): RabbitMQ management.
+  User and password are `dosomething`.
 
 ### Running app in development mode
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,63 @@ API gateway to Quicksilver (Message Broker) functionality.
 | `POST /campaign/signup`     | [Campaign signup](documentation/endpoints/campaign.md#campaign-signup)           | [campaign.signup.transactional](documentation/messages/campaign.signup.transactional.md)      |
 | `POST /campaign/reportback` | [Campaign report back](documentation/endpoints/campaign.md#campaign-report-back) | [campaign.report_back.transactional](documentation/messages/campaign.signup.transactional.md) |
 
+## Development.
+#### Requirements
+- [Node.js](https://nodejs.org/en/download/) v4.4
+- [Docker](https://www.docker.com/products/overview) with support
+  of Compose file [v2](https://docs.docker.com/compose/compose-file/#/versioning)
+  for running dependent services, for example RabbitMQ.
+
+#### Installation
+1. Install dependencies `npm install`
+2. Create config/local.js file with following settings:
+   
+```js
+   module.exports = {
+      // Northstar.
+      northstar: {
+        apiBaseURI: 'https://northstar-qa.dosomething.org/v1/users',
+        apiKey: '{{ nothstar_access_key }}',
+      },
+
+      // Phoenix.
+      phoenix: {
+       baseURI: 'https://staging.beta.dosomething.org/api/v1',
+       username: '{{ phoenix_api_user }}',
+       password: '{{ phoenix_api_pass }}',
+      },
+
+     // RabbitMQ
+     amqp: {
+       management: {
+         username: 'dosomething',
+         password: 'dosomething',
+         hostname: 'localhost:15672',
+         protocol: 'http',
+         vhost: 'dosomething',
+       },
+       connection: {
+         user: 'dosomething',
+         password: 'dosomething',
+         ssl: false,
+         host: 'localhost',
+         port: 5672,
+         vhost: 'dosomething',
+       },
+     },
+
+   };
+```
+
+#### Running Sails
+
+Run Sails as usual by executing `sails lift` or `npm start`.
+
+To automatically restart Sails on any changes to .js and .json files, run
+`nodemon` instead.
+
+
+
 ## Tests
 
 Master build status:

--- a/docker-compose-common-services.yml
+++ b/docker-compose-common-services.yml
@@ -1,0 +1,8 @@
+---
+version: '2'
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    environment:
+      RABBITMQ_DEFAULT_USER: 'dosomething'
+      RABBITMQ_DEFAULT_VHOST: 'dosomething'

--- a/docker-compose-development-host-only.yml
+++ b/docker-compose-development-host-only.yml
@@ -1,0 +1,13 @@
+---
+version: '2'
+services:
+  rabbitmq:
+    extends:
+      file: docker-compose-common-services.yml
+      service: rabbitmq
+    ports:
+      - 15672:15672 # Management
+      - 5672:5672 # AMQP
+    environment:
+      # Development password.
+      RABBITMQ_DEFAULT_PASS: 'dosomething'

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "debug": "sails debug",
     "start": "node app.js",
     "test": "npm run lint && NODE_ENV=test mocha test/bootstrap.test.js test/**/*.test.js",
-    "lint": "eslint --ext=.js test/ api/"
+    "lint": "eslint --ext=.js test/ api/",
+    "start-dev-services": "docker-compose -f docker-compose-development-host-only.yml up -d",
+    "stop-dev-services": "docker-compose -f docker-compose-development-host-only.yml stop"
   },
   "main": "app.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test": "npm run lint && NODE_ENV=test mocha test/bootstrap.test.js test/**/*.test.js",
     "lint": "eslint --ext=.js test/ api/",
     "start-dev-services": "docker-compose -f docker-compose-development-host-only.yml up -d",
-    "stop-dev-services": "docker-compose -f docker-compose-development-host-only.yml stop"
+    "stop-dev-services": "docker-compose -f docker-compose-development-host-only.yml down"
   },
   "main": "app.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,17 @@
     "type": "git",
     "url": "git+https://github.com/DoSomething/quicksilver-api.git"
   },
-  "author": "sergii",
+  "author": {
+    "name" : "Sergii Tkachenko",
+    "email" : "sergii@dosomething.org",
+    "url" : "https://github.com/sergii-tkachenko"
+  },
+  "contributors": [
+    {
+      "name" : "Darren \"Dee\" Lee",
+      "email" : "dee@dosomething.org",
+      "url" : "https://github.com/deezone"
+    }
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
#### What's this PR do?
- Provides Docker-compose configuration for RabbitMQ dev service
- Provides `start-dev-services` and `stop-dev-services` npm scripts to start and stop dependent dev services
- Document stuff!
